### PR TITLE
Add workflow to sign and generate TF provider for registry

### DIFF
--- a/.github/workflows/tf_provider_release.yaml
+++ b/.github/workflows/tf_provider_release.yaml
@@ -1,0 +1,38 @@
+name: Release Terraform Provider
+
+# This GitHub action creates a release when a tag that matches the pattern
+# "v*" (e.g. v0.1.0) is created.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        with:
+          # Allow goreleaser to access older tag information.
+          fetch-depth: 0
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.terraform_gpg_secret_key }}
+          passphrase: ${{ secrets.terraform_gpg_passphrase }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,4 @@
 
 Styra Declarative Authorization Service (DAS) - The Enterprise OPA Manager providing unified policy management across the cloud native stack.
 
-<!-- No SDK Installation -->
-<!-- No SDK Example Usage -->
-<!-- No SDK Available Operations -->
-<!-- Placeholder for Future Speakeasy SDK Sections -->
-
-
+This Styra DAS Terraform provider enables managing Styra DAS resources with Terraform.


### PR DESCRIPTION
Adds the GitHub workflow which will generate signed builds of the Styra DAS Terraform Provider for upload to the Terraform Registry.