### PR TITLE
Update .goreleaser.yml for v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
+
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing


### PR DESCRIPTION
This is to fix the goreleaser error when building the Terraform provider artifacts for the Terraform registry. The errors began occurring after goreleaser v2 was released this week.