### PR TITLE
Update .goreleaser.yml for GoReleaser v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,4 +59,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
GoReleaser v2 config appears to be slightly different for the `changelog` parameter. This PR updates the parameter for GoReleaser v2.