### PR TITLE
feat: enable use of env var for API token

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -18,5 +18,7 @@ terraform:
   additionalResources: []
   allowUnknownFieldsInWeakUnions: false
   author: StyraInc
-  environmentVariables: []
+  environmentVariables:
+    - env: STYRA_TOKEN
+      providerAttribute: bearer
   packageName: styra


### PR DESCRIPTION
Enable the Terraform provider to use the STYRA_TOKEN environment variable for the API token rather than defining as a TF var.